### PR TITLE
jenkinsがテスト環境のデータベースを占有

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -58,7 +58,9 @@ development:
 test:
   <<: *default
   database: tascal_test
-
+  username: jenkins
+  password: <%= ENV['JENKINS_DB_PASSWORD'] %>
+  
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.


### PR DESCRIPTION
警告: テストを書いている人はマージする前にこれを読んでください

test環境のDBは、ユーザー＆パスワードが設定されておらず、サーバー上の自動テストを実行する際不便です。
inside-hakumaiのプルリクと同じように、環境設定を直したうえでテスト用のユーザーだけからDBをアクセスできるようにしました。

これをマージすると一時的に`rails db:migrate RAILS_ENV=test` がコケるようになり、結果としてテストが実行できなくなります。
ローカルでテストを実行するためには、以下のようにpostgreSQLのユーザを追加してください
`$  sudo -u postgres psql`
`# create role jenkins with createdb login password 'password';` postgreSQLのプロンプト
`# drop database tascal_test`
`# \q`  postgreSQLのプロンプト終了
`$ echo export JENKINS_DB_PASSWORD="password" >> ~/.bashrc`
`$ source ~/.bashrc`

開発環境のすぐ横に建てる方式です。DBサーバーをdockerに分離したりしないので簡易的かと思います。